### PR TITLE
Rearrange full house cards to return correct order when low pairs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ Rake::TestTask.new do |t|
   t.libs = ['lib']
   t.verbose = true
   t.warning = true
-  t.test_files = FileList['test/test_card.rb', 'test/test_poker_hand.rb']
+  t.test_files = FileList['test/test_card.rb', 'test/test_poker_hand.rb', 'test/test_full_house.rb']
 end
 
 task :default => :test

--- a/lib/ruby-poker/poker_hand.rb
+++ b/lib/ruby-poker/poker_hand.rb
@@ -105,15 +105,13 @@ class PokerHand
 
   def full_house?
     if (md = (by_face =~ /(.). \1. \1. (.*)(.). \3./))
-      arranged_hand = arrange_hand(md[0] + ' ' +
-          md.pre_match + ' ' + md[2] + ' ' + md.post_match)
+      arranged_hand = rearrange_full_house(by_face.cards)
       [
         [7, Card::face_value(md[1]), Card::face_value(md[3])],
         arranged_hand
       ]
     elsif (md = (by_face =~ /((.). \2.) (.*)((.). \5. \5.)/))
-      arranged_hand = arrange_hand(md[4] + ' '  + md[1] + ' ' +
-          md.pre_match + ' ' + md[3] + ' ' + md.post_match)
+      arranged_hand = rearrange_full_house(by_face.cards)
       [
         [7, Card::face_value(md[5]), Card::face_value(md[2])],
         arranged_hand
@@ -503,6 +501,14 @@ class PokerHand
     arranged_hand.gsub!(/\s+/, ' ')
     # careful to use gsub as gsub! can return nil here
     arranged_hand.gsub(/\s+$/, '')
+  end
+
+  def rearrange_full_house(cards)
+    card_array = cards.split.uniq
+    card_hash = Hash[card_array.collect{|c| [c[0], card_array.count{|n| n[0] == c[0]}]}]
+    arranged_hand = card_array.select{|c| c if c[0] == card_hash.key(3)}
+    arranged_hand += card_array.select{|c| c if c[0] == card_hash.key(2)}
+    (arranged_hand + (card_array - arranged_hand)).join(" ")
   end
 
 end

--- a/test/test_full_house.rb
+++ b/test/test_full_house.rb
@@ -1,0 +1,32 @@
+require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+
+class TestFullHouse < Test::Unit::TestCase
+
+  context "A Full House should return the correct cards from sort_using_rank" do
+
+    setup do
+      @fh_high_pair = PokerHand.new("8h 8d 8c Qh Td Kd Ks")
+      @fh_low_pair = PokerHand.new("8h 8d 8c Qh Td 4h 4d")
+      @fh_high_trips = PokerHand.new("Kh Kd Kc Qh Td 8h 8d")
+      @fh_low_trips = PokerHand.new("4h 4d 4c Qh Td Kd Ks")
+    end
+
+    should "full house #sort_using_rank from seven cards (high pair) should return correct cards" do
+      assert_equal("8h 8d 8c Ks Kd Qh Td", @fh_high_pair.sort_using_rank)
+    end
+
+    should "full house #sort_using_rank from seven cards (low pair) should return correct cards" do
+      assert_equal("8h 8d 8c 4h 4d Qh Td", @fh_low_pair.sort_using_rank)
+    end
+
+    should "full house #sort_using_rank from seven cards (high trips) should return correct cards" do
+      assert_equal("Kh Kd Kc 8h 8d Qh Td", @fh_high_trips.sort_using_rank)
+    end
+
+    should "full house #sort_using_rank from seven cards (low trips) should return correct cards" do
+      assert_equal("4h 4d 4c Ks Kd Qh Td", @fh_low_trips.sort_using_rank)
+    end
+
+  end
+
+end


### PR DESCRIPTION
The full_house (arranged hand) was returning the incorrect card order when the pair was a lower value than the spare cards, this re arranges the order so that it always returns the trips > pair > spares
