### PR TITLE
Namespace classes inside RubyPoker module

### DIFF
--- a/lib/ruby-poker/card.rb
+++ b/lib/ruby-poker/card.rb
@@ -1,139 +1,142 @@
-class Card
-  SUITS = "cdhs"
-  FACES = "L23456789TJQKA"
-  SUIT_LOOKUP = {
-    'c' => 0,
-    'd' => 1,
-    'h' => 2,
-    's' => 3
-  }
-  FACE_VALUES = {
-    'L' =>  0,   # this is a low ace
-    '2' =>  1,
-    '3' =>  2,
-    '4' =>  3,
-    '5' =>  4,
-    '6' =>  5,
-    '7' =>  6,
-    '8' =>  7,
-    '9' =>  8,
-    'T' =>  9,
-    'J' => 10,
-    'Q' => 11,
-    'K' => 12,
-    'A' => 13
-  }
+module RubyPoker
+  class Card
+    SUITS = "cdhs"
+    FACES = "L23456789TJQKA"
+    SUIT_LOOKUP = {
+      'c' => 0,
+      'd' => 1,
+      'h' => 2,
+      's' => 3
+    }
+    FACE_VALUES = {
+      'L' => 0, # this is a low ace
+      '2' => 1,
+      '3' => 2,
+      '4' => 3,
+      '5' => 4,
+      '6' => 5,
+      '7' => 6,
+      '8' => 7,
+      '9' => 8,
+      'T' => 9,
+      'J' => 10,
+      'Q' => 11,
+      'K' => 12,
+      'A' => 13
+    }
 
-  def Card.face_value(face)
-    FACE_VALUES[face.upcase]
-  end
+    def Card.face_value(face)
+      FACE_VALUES[face.upcase]
+    end
 
-  private
+    private
 
-  def build_from_value(given_value)
-    @suit  = given_value / 13
-    @face  = given_value % 13
-  end
+    def build_from_value(given_value)
+      @suit = given_value / 13
+      @face = given_value % 13
+    end
 
-  def build_from_face_suit(face, suit)
-    suit.downcase!
-    @face  = Card::face_value(face)
-    @suit  = SUIT_LOOKUP[suit]
-    raise ArgumentError, "Invalid card: \"#{face}#{suit}\"" unless @face and @suit
-  end
+    def build_from_face_suit(face, suit)
+      suit.downcase!
+      @face = Card::face_value(face)
+      @suit = SUIT_LOOKUP[suit]
+      raise ArgumentError, "Invalid card: \"#{face}#{suit}\"" unless @face and @suit
+    end
 
-  def build_from_face_suit_values(face_int, suit_int)
-    @face = face_int
-    @suit = suit_int
-  end
+    def build_from_face_suit_values(face_int, suit_int)
+      @face = face_int
+      @suit = suit_int
+    end
 
-  def build_from_string(card)
-    build_from_face_suit(card[0,1], card[1,1])
-  end
+    def build_from_string(card)
+      build_from_face_suit(card[0, 1], card[1, 1])
+    end
 
-  # Constructs this card object from another card object
-  def build_from_card(card)
-    @suit = card.suit
-    @face = card.face
-  end
+    # Constructs this card object from another card object
+    def build_from_card(card)
+      @suit = card.suit
+      @face = card.face
+    end
 
-  public
+    public
 
-  def initialize(*args)
-    if (args.size == 1)
-      arg = args.first
-      if (arg.respond_to?(:to_card))
-        build_from_card(arg)
-      elsif (arg.respond_to?(:to_str))
-        build_from_string(arg)
-      elsif (arg.respond_to?(:to_int))
-        build_from_value(arg)
-      end
-    elsif (args.size == 2)
-      arg1, arg2 = args
-      if (arg1.respond_to?(:to_str) &&
+    def initialize(*args)
+      if (args.size == 1)
+        arg = args.first
+        if (arg.respond_to?(:to_card))
+          build_from_card(arg)
+        elsif (arg.respond_to?(:to_str))
+          build_from_string(arg)
+        elsif (arg.respond_to?(:to_int))
+          build_from_value(arg)
+        end
+      elsif (args.size == 2)
+        arg1, arg2 = args
+        if (arg1.respond_to?(:to_str) &&
           arg2.respond_to?(:to_str))
-        build_from_face_suit(arg1, arg2)
-      elsif (arg1.respond_to?(:to_int) &&
-             arg2.respond_to?(:to_int))
-        build_from_face_suit_values(arg1, arg2)
+          build_from_face_suit(arg1, arg2)
+        elsif (arg1.respond_to?(:to_int) &&
+          arg2.respond_to?(:to_int))
+          build_from_face_suit_values(arg1, arg2)
+        end
       end
     end
-  end
 
-  attr_reader :suit, :face
-  include Comparable
+    attr_reader :suit, :face
+    include Comparable
 
-  def value
-    (@suit * 13) + @face
-  end
+    def value
+      (@suit * 13) + @face
+    end
 
-  # Returns a string containing the representation of Card
-  #
-  # Card.new("7c").to_s                   # => "7c"
-  def to_s
-    FACES[@face].chr + SUITS[@suit].chr
-  end
+    # Returns a string containing the representation of Card
+    #
+    # Card.new("7c").to_s                   # => "7c"
+    def to_s
+      FACES[@face].chr + SUITS[@suit].chr
+    end
 
-  # If to_card is called on a `Card` it should return itself
-  def to_card
-    self
-  end
+    # If to_card is called on a `Card` it should return itself
+    def to_card
+      self
+    end
 
-  # Compare the face value of this card with another card. Returns:
-  # -1 if self is less than card2
-  # 0 if self is the same face value of card2
-  # 1 if self is greater than card2
-  def <=> card2
-    @face <=> card2.face
-  end
+    # Compare the face value of this card with another card. Returns:
+    # -1 if self is less than card2
+    # 0 if self is the same face value of card2
+    # 1 if self is greater than card2
+    def <=> card2
+      @face <=> card2.face
+    end
 
-  # Returns true if the cards are the same card. Meaning they
-  # have the same suit and the same face value.
-  def == card2
-    value == card2.value
-  end
-  alias :eql? :==
+    # Returns true if the cards are the same card. Meaning they
+    # have the same suit and the same face value.
+    def == card2
+      value == card2.value
+    end
 
-  # Compute a hash-code for this Card. Two Cards with the same
-  # content will have the same hash code (and will compare using eql?).
-  def hash
-    value.hash
-  end
+    alias :eql? :==
 
-  # A card's natural value is the closer to it's intuitive value in a deck
-  # in the range of 1 to 52. Aces are low with a value of 1. Uses the bridge
-  # order of suits: clubs, diamonds, hearts, and spades. The formula used is:
-  # If the suit is clubs, the natural value is the face value (remember
-  # Aces are low). If the suit is diamonds, it is the clubs value plus 13.
-  # If the suit is hearts, it is plus 26. If it is spades, it is plus 39.
-  #
-  #     Card.new("Ac").natural_value    # => 1
-  #     Card.new("Kc").natural_value    # => 12
-  #     Card.new("Ad").natural_value    # => 13
-  def natural_value
-    natural_face = @face == 13 ? 1 : @face+1  # flip Ace from 13 to 1 and
-                                              # increment everything else by 1
-    natural_face + @suit * 13
+    # Compute a hash-code for this Card. Two Cards with the same
+    # content will have the same hash code (and will compare using eql?).
+    def hash
+      value.hash
+    end
+
+    # A card's natural value is the closer to it's intuitive value in a deck
+    # in the range of 1 to 52. Aces are low with a value of 1. Uses the bridge
+    # order of suits: clubs, diamonds, hearts, and spades. The formula used is:
+    # If the suit is clubs, the natural value is the face value (remember
+    # Aces are low). If the suit is diamonds, it is the clubs value plus 13.
+    # If the suit is hearts, it is plus 26. If it is spades, it is plus 39.
+    #
+    #     Card.new("Ac").natural_value    # => 1
+    #     Card.new("Kc").natural_value    # => 12
+    #     Card.new("Ad").natural_value    # => 13
+    def natural_value
+      natural_face = @face == 13 ? 1 : @face+1 # flip Ace from 13 to 1 and
+      # increment everything else by 1
+      natural_face + @suit * 13
+    end
   end
 end

--- a/lib/ruby-poker/poker_hand.rb
+++ b/lib/ruby-poker/poker_hand.rb
@@ -1,514 +1,523 @@
-class PokerHand
-  include Comparable
-  include Enumerable
-  attr_reader :hand
+module RubyPoker
+  class PokerHand
+    include Comparable
+    include Enumerable
+    attr_reader :hand
 
-  @@allow_duplicates = true    # true by default
-  def self.allow_duplicates; @@allow_duplicates; end
-  def self.allow_duplicates=(v); @@allow_duplicates = v; end
+    @@allow_duplicates = true # true by default
+    def self.allow_duplicates;
+      @@allow_duplicates;
+    end
 
-  # Returns a new PokerHand object. Accepts the cards represented
-  # in a string or an array
-  #
-  #     PokerHand.new("3d 5c 8h Ks")   # => #<PokerHand:0x5c673c ...
-  #     PokerHand.new(["3d", "5c", "8h", "Ks"])  # => #<PokerHand:0x5c2d6c ...
-  def initialize(cards = [])
-    @hand = case cards
-    when Array
-      cards.map do |card|
-        if card.is_a? Card
-          card
-        else
-          Card.new(card.to_s)
+    def self.allow_duplicates=(v)
+      ; @@allow_duplicates = v;
+    end
+
+    # Returns a new PokerHand object. Accepts the cards represented
+    # in a string or an array
+    #
+    #     PokerHand.new("3d 5c 8h Ks")   # => #<PokerHand:0x5c673c ...
+    #     PokerHand.new(["3d", "5c", "8h", "Ks"])  # => #<PokerHand:0x5c2d6c ...
+    def initialize(cards = [])
+      @hand = case cards
+                when Array
+                  cards.map do |card|
+                    if card.is_a? Card
+                      card
+                    else
+                      Card.new(card.to_s)
+                    end
+                  end
+                when String
+                  cards.scan(/\S{2}/).map { |str| Card.new(str) }
+                else
+                  cards
+              end
+
+      check_for_duplicates unless allow_duplicates
+    end
+
+    # Returns a new PokerHand object with the cards sorted by suit
+    # The suit order is spades, hearts, diamonds, clubs
+    #
+    #     PokerHand.new("3d 5c 8h Ks").by_suit.just_cards   # => "Ks 8h 3d 5c"
+    def by_suit
+      PokerHand.new(@hand.sort_by { |c| [c.suit, c.face] }.reverse)
+    end
+
+    # Returns a new PokerHand object with the cards sorted by face value
+    # with the highest value first.
+    #
+    #     PokerHand.new("3d 5c 8h Ks").by_face.just_cards   # => "Ks 8h 5c 3d"
+    def by_face
+      PokerHand.new(@hand.sort_by { |c| [c.face, c.suit] }.reverse)
+    end
+
+    # Returns string representation of the hand without the rank
+    #
+    #     PokerHand.new(["3c", "Kh"]).just_cards     # => "3c Kh"
+    def just_cards
+      @hand.join(" ")
+    end
+
+    alias :cards :just_cards
+
+    # Returns an array of the card values in the hand.
+    # The values returned are 1 less than the value on the card.
+    # For example: 2's will be shown as 1.
+    #
+    #     PokerHand.new(["3c", "Kh"]).face_values     # => [2, 12]
+    def face_values
+      @hand.map { |c| c.face }
+    end
+
+    # The =~ method does a regular expression match on the cards in this hand.
+    # This can be useful for many purposes. A common use is the check if a card
+    # exists in a hand.
+    #
+    #     PokerHand.new("3d 4d 5d") =~ /8h/           # => nil
+    #     PokerHand.new("3d 4d 5d") =~ /4d/           # => #<MatchData:0x615e18>
+    def =~ (re)
+      re.match(just_cards)
+    end
+
+    def royal_flush?
+      if (md = (by_suit =~ /A(.) K\1 Q\1 J\1 T\1/))
+        [[10], arrange_hand(md)]
+      else
+        false
+      end
+    end
+
+    def straight_flush?
+      if (md = (/.(.)(.)(?: 1.\2){4}/.match(delta_transform(true))))
+        high_card = Card::face_value(md[1])
+        arranged_hand = fix_low_ace_display(md[0] + ' ' +
+                                              md.pre_match + ' ' + md.post_match)
+        [[9, high_card], arranged_hand]
+      else
+        false
+      end
+    end
+
+    def four_of_a_kind?
+      if (md = (by_face =~ /(.). \1. \1. \1./))
+        # get kicker
+        result = [8, Card::face_value(md[1])]
+        result << Card::face_value($1) if (md.pre_match + md.post_match).match(/(\S)/)
+        return [result, arrange_hand(md)]
+      end
+      false
+    end
+
+    def full_house?
+      if (md = (by_face =~ /(.). \1. \1. (.*)(.). \3./))
+        arranged_hand = rearrange_full_house(by_face.cards)
+        [
+          [7, Card::face_value(md[1]), Card::face_value(md[3])],
+          arranged_hand
+        ]
+      elsif (md = (by_face =~ /((.). \2.) (.*)((.). \5. \5.)/))
+        arranged_hand = rearrange_full_house(by_face.cards)
+        [
+          [7, Card::face_value(md[5]), Card::face_value(md[2])],
+          arranged_hand
+        ]
+      else
+        false
+      end
+    end
+
+    def flush?
+      if (md = (by_suit =~ /(.)(.) (.)\2 (.)\2 (.)\2 (.)\2/))
+        [
+          [
+            6,
+            Card::face_value(md[1]),
+            *(md[3..6].map { |f| Card::face_value(f) })
+          ],
+          arrange_hand(md)
+        ]
+      else
+        false
+      end
+    end
+
+    def straight?
+      if hand.size >= 5
+        transform = delta_transform
+        # note we can have more than one delta 0 that we
+        # need to shuffle to the back of the hand
+        i = 0
+        until transform.match(/^\S{3}( [1-9x]\S\S)+( 0\S\S)*$/) or i >= hand.size do
+          # only do this once per card in the hand to avoid entering an
+          # infinite loop if all of the cards in the hand are the same
+          transform.gsub!(/(\s0\S\S)(.*)/, "\\2\\1") # moves the front card to the back of the string
+          i += 1
+        end
+        if (md = (/.(.). 1.. 1.. 1.. 1../.match(transform)))
+          high_card = Card::face_value(md[1])
+          arranged_hand = fix_low_ace_display(md[0] + ' ' + md.pre_match + ' ' + md.post_match)
+          return [[5, high_card], arranged_hand]
         end
       end
-    when String
-      cards.scan(/\S{2}/).map { |str| Card.new(str) }
-    else
-      cards
-    end
-
-    check_for_duplicates unless allow_duplicates
-  end
-
-  # Returns a new PokerHand object with the cards sorted by suit
-  # The suit order is spades, hearts, diamonds, clubs
-  #
-  #     PokerHand.new("3d 5c 8h Ks").by_suit.just_cards   # => "Ks 8h 3d 5c"
-  def by_suit
-    PokerHand.new(@hand.sort_by { |c| [c.suit, c.face] }.reverse)
-  end
-
-  # Returns a new PokerHand object with the cards sorted by face value
-  # with the highest value first.
-  #
-  #     PokerHand.new("3d 5c 8h Ks").by_face.just_cards   # => "Ks 8h 5c 3d"
-  def by_face
-    PokerHand.new(@hand.sort_by { |c| [c.face, c.suit] }.reverse)
-  end
-
-  # Returns string representation of the hand without the rank
-  #
-  #     PokerHand.new(["3c", "Kh"]).just_cards     # => "3c Kh"
-  def just_cards
-    @hand.join(" ")
-  end
-  alias :cards :just_cards
-
-  # Returns an array of the card values in the hand.
-  # The values returned are 1 less than the value on the card.
-  # For example: 2's will be shown as 1.
-  #
-  #     PokerHand.new(["3c", "Kh"]).face_values     # => [2, 12]
-  def face_values
-    @hand.map { |c| c.face }
-  end
-
-  # The =~ method does a regular expression match on the cards in this hand.
-  # This can be useful for many purposes. A common use is the check if a card
-  # exists in a hand.
-  #
-  #     PokerHand.new("3d 4d 5d") =~ /8h/           # => nil
-  #     PokerHand.new("3d 4d 5d") =~ /4d/           # => #<MatchData:0x615e18>
-  def =~ (re)
-    re.match(just_cards)
-  end
-
-  def royal_flush?
-    if (md = (by_suit =~ /A(.) K\1 Q\1 J\1 T\1/))
-      [[10], arrange_hand(md)]
-    else
       false
     end
-  end
 
-  def straight_flush?
-    if (md = (/.(.)(.)(?: 1.\2){4}/.match(delta_transform(true))))
-      high_card = Card::face_value(md[1])
-      arranged_hand = fix_low_ace_display(md[0] + ' ' +
-          md.pre_match + ' ' + md.post_match)
-      [[9, high_card], arranged_hand]
-    else
+    def three_of_a_kind?
+      if (md = (by_face =~ /(.). \1. \1./))
+        # get kicker
+        arranged_hand = arrange_hand(md)
+        matches = arranged_hand.match(/(?:\S\S ){2}(\S\S)/)
+        if matches
+          result = [4, Card::face_value(md[1])]
+          matches = arranged_hand.match(/(?:\S\S ){3}(\S)/)
+          result << Card::face_value($1) if matches
+          matches = arranged_hand.match(/(?:\S\S ){3}(\S)\S (\S)/)
+          result << Card::face_value($2) if matches
+          return [result, arranged_hand]
+        end
+      end
       false
     end
-  end
 
-  def four_of_a_kind?
-    if (md = (by_face =~ /(.). \1. \1. \1./))
-      # get kicker
-      result = [8, Card::face_value(md[1])]
-      result << Card::face_value($1) if (md.pre_match + md.post_match).match(/(\S)/)
-      return [result, arrange_hand(md)]
-    end
-    false
-  end
-
-  def full_house?
-    if (md = (by_face =~ /(.). \1. \1. (.*)(.). \3./))
-      arranged_hand = rearrange_full_house(by_face.cards)
-      [
-        [7, Card::face_value(md[1]), Card::face_value(md[3])],
-        arranged_hand
-      ]
-    elsif (md = (by_face =~ /((.). \2.) (.*)((.). \5. \5.)/))
-      arranged_hand = rearrange_full_house(by_face.cards)
-      [
-        [7, Card::face_value(md[5]), Card::face_value(md[2])],
-        arranged_hand
-      ]
-    else
+    def two_pair?
+      # \1 is the face value of the first pair
+      # \2 is the card in between the first pair and the second pair
+      # \3 is the face value of the second pair
+      if (md = (by_face =~ /(.). \1.(.*?) (.). \3./))
+        # to get the kicker this does the following
+        # md[0] is the regex matched above which includes the first pair and
+        # the second pair but also some cards in the middle so we sub them out
+        # then we add on the cards that came before the first pair, the cards
+        # that were in-between, and the cards that came after.
+        arranged_hand = arrange_hand(md[0].sub(md[2], '') + ' ' +
+                                       md.pre_match + ' ' + md[2] + ' ' + md.post_match)
+        matches = arranged_hand.match(/(?:\S\S ){3}(\S\S)/)
+        if matches
+          result = []
+          result << 3
+          result << Card::face_value(md[1]) # face value of the first pair
+          result << Card::face_value(md[3]) # face value of the second pair
+          matches = arranged_hand.match(/(?:\S\S ){4}(\S)/)
+          result << Card::face_value($1) if matches # face value of the kicker
+          return [result, arranged_hand]
+        end
+      end
       false
     end
-  end
 
-  def flush?
-    if (md = (by_suit =~ /(.)(.) (.)\2 (.)\2 (.)\2 (.)\2/))
-      [
-        [
-          6,
-          Card::face_value(md[1]),
-          *(md[3..6].map { |f| Card::face_value(f) })
-        ],
-        arrange_hand(md)
-      ]
-    else
-      false
-    end
-  end
+    def pair?
+      if (md = (by_face =~ /(.). \1./))
+        arranged_hand_str = arrange_hand(md)
+        arranged_hand = PokerHand.new(arranged_hand_str)
 
-  def straight?
-    if hand.size >= 5
-      transform = delta_transform
-      # note we can have more than one delta 0 that we
-      # need to shuffle to the back of the hand
-      i = 0
-      until transform.match(/^\S{3}( [1-9x]\S\S)+( 0\S\S)*$/) or i >= hand.size  do
-        # only do this once per card in the hand to avoid entering an
-        # infinite loop if all of the cards in the hand are the same
-        transform.gsub!(/(\s0\S\S)(.*)/, "\\2\\1")    # moves the front card to the back of the string
-        i += 1
-      end
-      if (md = (/.(.). 1.. 1.. 1.. 1../.match(transform)))
-        high_card = Card::face_value(md[1])
-        arranged_hand = fix_low_ace_display(md[0] + ' ' + md.pre_match + ' ' + md.post_match)
-        return [[5, high_card], arranged_hand]
-      end
-    end
-    false
-  end
-
-  def three_of_a_kind?
-    if (md = (by_face =~ /(.). \1. \1./))
-      # get kicker
-      arranged_hand = arrange_hand(md)
-      matches = arranged_hand.match(/(?:\S\S ){2}(\S\S)/)
-      if matches
-        result = [4, Card::face_value(md[1])]
-        matches = arranged_hand.match(/(?:\S\S ){3}(\S)/)
-        result << Card::face_value($1) if matches
-        matches = arranged_hand.match(/(?:\S\S ){3}(\S)\S (\S)/)
-        result << Card::face_value($2) if matches
-        return [result, arranged_hand]
-      end
-    end
-    false
-  end
-
-  def two_pair?
-    # \1 is the face value of the first pair
-    # \2 is the card in between the first pair and the second pair
-    # \3 is the face value of the second pair
-    if (md = (by_face =~ /(.). \1.(.*?) (.). \3./))
-      # to get the kicker this does the following
-      # md[0] is the regex matched above which includes the first pair and
-      # the second pair but also some cards in the middle so we sub them out
-      # then we add on the cards that came before the first pair, the cards
-      # that were in-between, and the cards that came after.
-      arranged_hand = arrange_hand(md[0].sub(md[2], '') + ' ' +
-          md.pre_match + ' ' + md[2] + ' ' + md.post_match)
-      matches = arranged_hand.match(/(?:\S\S ){3}(\S\S)/)
-      if matches
-        result = []
-        result << 3
-        result << Card::face_value(md[1])    # face value of the first pair
-        result << Card::face_value(md[3])    # face value of the second pair
-        matches = arranged_hand.match(/(?:\S\S ){4}(\S)/)
-        result << Card::face_value($1) if matches    # face value of the kicker
-      return [result, arranged_hand]
-      end
-    end
-    false
-  end
-
-  def pair?
-    if (md = (by_face =~ /(.). \1./))
-      arranged_hand_str = arrange_hand(md)
-      arranged_hand = PokerHand.new(arranged_hand_str)
-
-      if arranged_hand.hand[0].face == arranged_hand.hand[1].face &&
+        if arranged_hand.hand[0].face == arranged_hand.hand[1].face &&
           arranged_hand.hand[0].suit != arranged_hand.hand[1].suit
-        result = [2, arranged_hand.hand[0].face]
-        result << arranged_hand.hand[2].face if arranged_hand.size > 2
-        result << arranged_hand.hand[3].face if arranged_hand.size > 3
-        result << arranged_hand.hand[4].face if arranged_hand.size > 4
+          result = [2, arranged_hand.hand[0].face]
+          result << arranged_hand.hand[2].face if arranged_hand.size > 2
+          result << arranged_hand.hand[3].face if arranged_hand.size > 3
+          result << arranged_hand.hand[4].face if arranged_hand.size > 4
 
-        return [result, arranged_hand_str]
+          return [result, arranged_hand_str]
+        end
+      else
+        false
       end
-    else
-      false
-    end
-  end
-
-  def highest_card?
-    if size > 0
-      result = by_face
-      [[1, *result.face_values[0..result.face_values.length]], result.hand.join(' ')]
-    else
-      false
-    end
-  end
-
-  def empty_hand?
-    if size == 0
-      [[0]]
-    end
-  end
-
-  OPS = [
-    ['Royal Flush',     :royal_flush? ],
-    ['Straight Flush',  :straight_flush? ],
-    ['Four of a kind',  :four_of_a_kind? ],
-    ['Full house',      :full_house? ],
-    ['Flush',           :flush? ],
-    ['Straight',        :straight? ],
-    ['Three of a kind', :three_of_a_kind?],
-    ['Two pair',        :two_pair? ],
-    ['Pair',            :pair? ],
-    ['Highest Card',    :highest_card? ],
-    ['Empty Hand',      :empty_hand? ],
-  ]
-
-  # Returns the verbose hand rating
-  #
-  #     PokerHand.new("4s 5h 6c 7d 8s").hand_rating     # => "Straight"
-  def hand_rating
-    OPS.map { |op|
-      (method(op[1]).call()) ? op[0] : false
-    }.find { |v| v }
-  end
-
-  alias :rank :hand_rating
-
-  def score
-    # OPS.map returns an array containing the result of calling each OPS method against
-    # the poker hand. The truthy cell closest to the front of the array represents
-    # the highest ranking.
-    OPS.map { |op|
-      method(op[1]).call()
-    }.find { |score| score }
-  end
-
-  # Returns a string of the hand arranged based on its rank. Usually this will be the
-  # same as by_face but there are some cases where it makes a difference.
-  #
-  #     ph = PokerHand.new("As 3s 5s 2s 4s")
-  #     ph.sort_using_rank        # => "5s 4s 3s 2s As"
-  #     ph.by_face.just_cards       # => "As 5s 4s 3s 2s"
-  def sort_using_rank
-    score[1]
-  end
-
-  # Returns string with a listing of the cards in the hand followed by the hand's rank.
-  #
-  #     h = PokerHand.new("8c 8s")
-  #     h.to_s                      # => "8c 8s (Pair)"
-  def to_s
-    just_cards + " (" + hand_rating + ")"
-  end
-
-  # Returns an array of `Card` objects that make up the `PokerHand`.
-  def to_a
-    @hand
-  end
-  alias :to_ary :to_a
-
-  def <=> other_hand
-    self.score[0].compact <=> other_hand.score[0].compact
-  end
-
-  # Add a card to the hand
-  #
-  #     hand = PokerHand.new("5d")
-  #     hand << "6s"          # => Add a six of spades to the hand by passing a string
-  #     hand << ["7h", "8d"]  # => Add multiple cards to the hand using an array
-  def << new_cards
-    if new_cards.is_a?(Card) || new_cards.is_a?(String)
-      new_cards = [new_cards]
     end
 
-    new_cards.each do |nc|
-      unless allow_duplicates
-        raise "A card with the value #{nc} already exists in this hand. Set PokerHand.allow_duplicates to true if you want to be able to add a card more than once." if self =~ /#{nc}/
+    def highest_card?
+      if size > 0
+        result = by_face
+        [[1, *result.face_values[0..result.face_values.length]], result.hand.join(' ')]
+      else
+        false
+      end
+    end
+
+    def empty_hand?
+      if size == 0
+        [[0]]
+      end
+    end
+
+    OPS = [
+      ['Royal Flush', :royal_flush?],
+      ['Straight Flush', :straight_flush?],
+      ['Four of a kind', :four_of_a_kind?],
+      ['Full house', :full_house?],
+      ['Flush', :flush?],
+      ['Straight', :straight?],
+      ['Three of a kind', :three_of_a_kind?],
+      ['Two pair', :two_pair?],
+      ['Pair', :pair?],
+      ['Highest Card', :highest_card?],
+      ['Empty Hand', :empty_hand?],
+    ]
+
+    # Returns the verbose hand rating
+    #
+    #     PokerHand.new("4s 5h 6c 7d 8s").hand_rating     # => "Straight"
+    def hand_rating
+      OPS.map { |op|
+        (method(op[1]).call()) ? op[0] : false
+      }.find { |v| v }
+    end
+
+    alias :rank :hand_rating
+
+    def score
+      # OPS.map returns an array containing the result of calling each OPS method against
+      # the poker hand. The truthy cell closest to the front of the array represents
+      # the highest ranking.
+      OPS.map { |op|
+        method(op[1]).call()
+      }.find { |score| score }
+    end
+
+    # Returns a string of the hand arranged based on its rank. Usually this will be the
+    # same as by_face but there are some cases where it makes a difference.
+    #
+    #     ph = PokerHand.new("As 3s 5s 2s 4s")
+    #     ph.sort_using_rank        # => "5s 4s 3s 2s As"
+    #     ph.by_face.just_cards       # => "As 5s 4s 3s 2s"
+    def sort_using_rank
+      score[1]
+    end
+
+    # Returns string with a listing of the cards in the hand followed by the hand's rank.
+    #
+    #     h = PokerHand.new("8c 8s")
+    #     h.to_s                      # => "8c 8s (Pair)"
+    def to_s
+      just_cards + " (" + hand_rating + ")"
+    end
+
+    # Returns an array of `Card` objects that make up the `PokerHand`.
+    def to_a
+      @hand
+    end
+
+    alias :to_ary :to_a
+
+    def <=> other_hand
+      self.score[0].compact <=> other_hand.score[0].compact
+    end
+
+    # Add a card to the hand
+    #
+    #     hand = PokerHand.new("5d")
+    #     hand << "6s"          # => Add a six of spades to the hand by passing a string
+    #     hand << ["7h", "8d"]  # => Add multiple cards to the hand using an array
+    def << new_cards
+      if new_cards.is_a?(Card) || new_cards.is_a?(String)
+        new_cards = [new_cards]
       end
 
-      @hand << Card.new(nc)
+      new_cards.each do |nc|
+        unless allow_duplicates
+          raise "A card with the value #{nc} already exists in this hand. Set PokerHand.allow_duplicates to true if you want to be able to add a card more than once." if self =~ /#{nc}/
+        end
+
+        @hand << Card.new(nc)
+      end
     end
-  end
 
-  # Remove a card from the hand.
-  #
-  #     hand = PokerHand.new("5d Jd")
-  #     hand.delete("Jd")           # => #<Card:0x5d0674 @value=23, @face=10, @suit=1>
-  #     hand.just_cards             # => "5d"
-  def delete card
-    @hand.delete(Card.new(card))
-  end
+    # Remove a card from the hand.
+    #
+    #     hand = PokerHand.new("5d Jd")
+    #     hand.delete("Jd")           # => #<Card:0x5d0674 @value=23, @face=10, @suit=1>
+    #     hand.just_cards             # => "5d"
+    def delete card
+      @hand.delete(Card.new(card))
+    end
 
-  # Same concept as Array#uniq
-  def uniq
-    PokerHand.new(@hand.uniq)
-  end
+    # Same concept as Array#uniq
+    def uniq
+      PokerHand.new(@hand.uniq)
+    end
 
-  # Resolving methods are just passed directly down to the @hand array
-  RESOLVING_METHODS = [:each, :size, :-]
-  RESOLVING_METHODS.each do |method|
-    class_eval %{
+    # Resolving methods are just passed directly down to the @hand array
+    RESOLVING_METHODS = [:each, :size, :-]
+    RESOLVING_METHODS.each do |method|
+      class_eval %{
       def #{method}(*args, &block)
         @hand.#{method}(*args, &block)
       end
     }
-  end
-
-  def allow_duplicates
-    @@allow_duplicates
-  end
-
-  # Checks whether the hand matches usual expressions like AA, AK, AJ+, 66+, AQs, AQo...
-  #
-  # Valid expressions:
-  # * "AJ": Matches exact faces (in this case an Ace and a Jack), suited or not
-  # * "AJs": Same but suited only
-  # * "AJo": Same but offsuit only
-  # * "AJ+": Matches an Ace with any card >= Jack, suited or not
-  # * "AJs+": Same but suited only
-  # * "AJo+": Same but offsuit only
-  # * "JJ+": Matches any pair >= "JJ".
-  # * "8T+": Matches connectors (in this case with 1 gap : 8T, 9J, TQ, JK, QA)
-  # * "8Ts+": Same but suited only
-  # * "8To+": Same but offsuit only
-  #
-  # The order of the cards in the expression is important (8T+ is not the same as T8+), but the order of the cards in the hand is not ("AK" will match "Ad Kc" and "Kc Ad").
-  #
-  # The expression can be an array of expressions. In this case the method returns true if any expression matches.
-  #
-  # This method only works on hands with 2 cards.
-  #
-  #     PokerHand.new('Ah Ad').match? 'AA' # => true
-  #     PokerHand.new('Ah Kd').match? 'AQ+' # => true
-  #     PokerHand.new('Jc Qc').match? '89s+' # => true
-  #     PokerHand.new('Ah Jd').match? %w( 22+ A6s+ AJ+ ) # => true
-  #     PokerHand.new('Ah Td').match? %w( 22+ A6s+ AJ+ ) # => false
-  #
-  def match? expression
-    raise "Hands with #{@hand.size} cards is not supported" unless @hand.size == 2
-
-    if expression.is_a? Array
-      return expression.any? { |e| match?(e) }
     end
 
-    faces = @hand.map { |card| card.face }.sort.reverse
-    suited = @hand.map { |card| card.suit }.uniq.size == 1
-    if expression =~ /^(.)(.)(s|o|)(\+|)$/
-      face1 = Card.face_value($1)
-      face2 = Card.face_value($2)
-      raise ArgumentError, "Invalid expression: #{expression.inspect}" unless face1 and face2
-      suit_match = $3
-      plus = ($4 != "")
+    def allow_duplicates
+      @@allow_duplicates
+    end
 
-      if plus
-        if face1 == face2
-          face_match = (faces.first == faces.last and faces.first >= face1)
-        elsif face1 > face2
-          face_match = (faces.first == face1 and faces.last >= face2)
+    # Checks whether the hand matches usual expressions like AA, AK, AJ+, 66+, AQs, AQo...
+    #
+    # Valid expressions:
+    # * "AJ": Matches exact faces (in this case an Ace and a Jack), suited or not
+    # * "AJs": Same but suited only
+    # * "AJo": Same but offsuit only
+    # * "AJ+": Matches an Ace with any card >= Jack, suited or not
+    # * "AJs+": Same but suited only
+    # * "AJo+": Same but offsuit only
+    # * "JJ+": Matches any pair >= "JJ".
+    # * "8T+": Matches connectors (in this case with 1 gap : 8T, 9J, TQ, JK, QA)
+    # * "8Ts+": Same but suited only
+    # * "8To+": Same but offsuit only
+    #
+    # The order of the cards in the expression is important (8T+ is not the same as T8+), but the order of the cards in the hand is not ("AK" will match "Ad Kc" and "Kc Ad").
+    #
+    # The expression can be an array of expressions. In this case the method returns true if any expression matches.
+    #
+    # This method only works on hands with 2 cards.
+    #
+    #     PokerHand.new('Ah Ad').match? 'AA' # => true
+    #     PokerHand.new('Ah Kd').match? 'AQ+' # => true
+    #     PokerHand.new('Jc Qc').match? '89s+' # => true
+    #     PokerHand.new('Ah Jd').match? %w( 22+ A6s+ AJ+ ) # => true
+    #     PokerHand.new('Ah Td').match? %w( 22+ A6s+ AJ+ ) # => false
+    #
+    def match? expression
+      raise "Hands with #{@hand.size} cards is not supported" unless @hand.size == 2
+
+      if expression.is_a? Array
+        return expression.any? { |e| match?(e) }
+      end
+
+      faces = @hand.map { |card| card.face }.sort.reverse
+      suited = @hand.map { |card| card.suit }.uniq.size == 1
+      if expression =~ /^(.)(.)(s|o|)(\+|)$/
+        face1 = Card.face_value($1)
+        face2 = Card.face_value($2)
+        raise ArgumentError, "Invalid expression: #{expression.inspect}" unless face1 and face2
+        suit_match = $3
+        plus = ($4 != "")
+
+        if plus
+          if face1 == face2
+            face_match = (faces.first == faces.last and faces.first >= face1)
+          elsif face1 > face2
+            face_match = (faces.first == face1 and faces.last >= face2)
+          else
+            face_match = ((faces.first - faces.last) == (face2 - face1) and faces.last >= face1)
+          end
         else
-          face_match = ((faces.first - faces.last) == (face2 - face1) and faces.last >= face1)
+          expression_faces = [face1, face2].sort.reverse
+          face_match = (expression_faces == faces)
+        end
+        case suit_match
+          when ''
+            face_match
+          when 's'
+            face_match and suited
+          when 'o'
+            face_match and !suited
         end
       else
-        expression_faces = [face1, face2].sort.reverse
-        face_match = (expression_faces == faces)
+        raise ArgumentError, "Invalid expression: #{expression.inspect}"
       end
-      case suit_match
-      when ''
-        face_match
-      when 's'
-        face_match and suited
-      when 'o'
-        face_match and !suited
+    end
+
+    def +(other)
+      cards = @hand.map { |card| Card.new(card) }
+      case other
+        when String
+          cards << Card.new(other)
+        when Card
+          cards << other
+        when PokerHand
+          cards += other.hand
+        else
+          raise ArgumentError, "Invalid argument: #{other.inspect}"
       end
-    else
-      raise ArgumentError, "Invalid expression: #{expression.inspect}"
+      PokerHand.new(cards)
     end
-  end
 
-  def +(other)
-    cards = @hand.map { |card| Card.new(card) }
-    case other
-    when String
-      cards << Card.new(other)
-    when Card
-      cards << other
-    when PokerHand
-      cards += other.hand
-    else
-      raise ArgumentError, "Invalid argument: #{other.inspect}"
+    private
+
+    def check_for_duplicates
+      if @hand.size != @hand.uniq.size && !allow_duplicates
+        raise "Attempting to create a hand that contains duplicate cards. Set PokerHand.allow_duplicates to true if you do not want to ignore this error."
+      end
     end
-    PokerHand.new(cards)
-  end
 
-  private
-
-  def check_for_duplicates
-    if @hand.size != @hand.uniq.size && !allow_duplicates
-      raise "Attempting to create a hand that contains duplicate cards. Set PokerHand.allow_duplicates to true if you do not want to ignore this error."
-    end
-  end
-
-  # if md is a string, arrange_hand will remove extra white space
-  # if md is a MatchData, arrange_hand returns the matched segment
-  # followed by the pre_match and the post_match
-  def arrange_hand(md)
+    # if md is a string, arrange_hand will remove extra white space
+    # if md is a MatchData, arrange_hand returns the matched segment
+    # followed by the pre_match and the post_match
+    def arrange_hand(md)
       hand = if md.respond_to?(:to_str)
-        md
-      else
-        md[0] + ' ' + md.pre_match + md.post_match
-      end
-      hand.strip.squeeze(" ")   # remove extra whitespace
-  end
-
-  # delta transform returns a string representation of the cards where the
-  # delta between card values is in the string. This is necessary so a regexp
-  # can then match a straight and/or straight flush
-  #
-  # Examples
-  #
-  #   PokerHand.new("As Qc Jh Ts 9d 8h")
-  #   # => '0As 2Qc 1Jh 1Ts 19d 18h'
-  #
-  #   PokerHand.new("Ah Qd Td 5d 4d")
-  #   # => '0Ah 2Qd 2Td 55d 14d'
-  #
-  def delta_transform(use_suit = false)
-    # In order to check for both ace high and ace low straights we create low
-    # ace duplicates of all of the high aces.
-    aces = @hand.select { |c| c.face == Card::face_value('A') }
-    aces.map! { |c| Card.new(0, c.suit) }  # hack to give the appearance of a low ace
-
-    base = if (use_suit)
-      (@hand + aces).sort_by { |c| [c.suit, c.face] }.reverse
-    else
-      (@hand + aces).sort_by { |c| [c.face, c.suit] }.reverse
+               md
+             else
+               md[0] + ' ' + md.pre_match + md.post_match
+             end
+      hand.strip.squeeze(" ") # remove extra whitespace
     end
 
-    # Insert delta in front of each card
-    result = base.inject(['',nil]) do |(delta_hand, prev_card), card|
-      if (prev_card)
-        delta = prev_card - card.face
-      else
-        delta = 0
+    # delta transform returns a string representation of the cards where the
+    # delta between card values is in the string. This is necessary so a regexp
+    # can then match a straight and/or straight flush
+    #
+    # Examples
+    #
+    #   PokerHand.new("As Qc Jh Ts 9d 8h")
+    #   # => '0As 2Qc 1Jh 1Ts 19d 18h'
+    #
+    #   PokerHand.new("Ah Qd Td 5d 4d")
+    #   # => '0Ah 2Qd 2Td 55d 14d'
+    #
+    def delta_transform(use_suit = false)
+      # In order to check for both ace high and ace low straights we create low
+      # ace duplicates of all of the high aces.
+      aces = @hand.select { |c| c.face == Card::face_value('A') }
+      aces.map! { |c| Card.new(0, c.suit) } # hack to give the appearance of a low ace
+
+      base = if (use_suit)
+               (@hand + aces).sort_by { |c| [c.suit, c.face] }.reverse
+             else
+               (@hand + aces).sort_by { |c| [c.face, c.suit] }.reverse
+             end
+
+      # Insert delta in front of each card
+      result = base.inject(['', nil]) do |(delta_hand, prev_card), card|
+        if (prev_card)
+          delta = prev_card - card.face
+        else
+          delta = 0
+        end
+        # does not really matter for my needs
+        delta = 'x' if (delta > 9 || delta < 0)
+        delta_hand += delta.to_s + card.to_s + ' '
+        [delta_hand, card.face]
       end
-      # does not really matter for my needs
-      delta = 'x' if (delta > 9 || delta < 0)
-      delta_hand += delta.to_s + card.to_s + ' '
-      [delta_hand, card.face]
+
+      # we just want the delta transform, not the last cards face too
+      result[0].chop
     end
 
-    # we just want the delta transform, not the last cards face too
-    result[0].chop
+    def fix_low_ace_display(arranged_hand)
+      # remove card deltas (this routine is only used for straights)
+      arranged_hand.gsub!(/\S(\S\S)\s*/, "\\1 ")
+
+      # Fix "low aces"
+      arranged_hand.gsub!(/L(\S)/, "A\\1")
+
+      # Remove duplicate aces (this will not work if you have
+      # multiple decks or wild cards)
+      arranged_hand.gsub!(/((A\S).*)\2/, "\\1")
+
+      # cleanup white space
+      arranged_hand.gsub!(/\s+/, ' ')
+      # careful to use gsub as gsub! can return nil here
+      arranged_hand.gsub(/\s+$/, '')
+    end
+
+    def rearrange_full_house(cards)
+      card_array = cards.split.uniq
+      card_hash = Hash[card_array.collect { |c| [c[0], card_array.count { |n| n[0] == c[0] }] }]
+      arranged_hand = card_array.select { |c| c if c[0] == card_hash.key(3) }
+      arranged_hand += card_array.select { |c| c if c[0] == card_hash.key(2) }
+      (arranged_hand + (card_array - arranged_hand)).join(" ")
+    end
+
   end
-
-  def fix_low_ace_display(arranged_hand)
-    # remove card deltas (this routine is only used for straights)
-    arranged_hand.gsub!(/\S(\S\S)\s*/, "\\1 ")
-
-    # Fix "low aces"
-    arranged_hand.gsub!(/L(\S)/, "A\\1")
-
-    # Remove duplicate aces (this will not work if you have
-    # multiple decks or wild cards)
-    arranged_hand.gsub!(/((A\S).*)\2/, "\\1")
-
-    # cleanup white space
-    arranged_hand.gsub!(/\s+/, ' ')
-    # careful to use gsub as gsub! can return nil here
-    arranged_hand.gsub(/\s+$/, '')
-  end
-
-  def rearrange_full_house(cards)
-    card_array = cards.split.uniq
-    card_hash = Hash[card_array.collect{|c| [c[0], card_array.count{|n| n[0] == c[0]}]}]
-    arranged_hand = card_array.select{|c| c if c[0] == card_hash.key(3)}
-    arranged_hand += card_array.select{|c| c if c[0] == card_hash.key(2)}
-    (arranged_hand + (card_array - arranged_hand)).join(" ")
-  end
-
 end

--- a/test/integration/test_a_million_hands.rb
+++ b/test/integration/test_a_million_hands.rb
@@ -87,10 +87,10 @@ File.new(data_file).each do |line|
     # in ruby-poker Aces have the highest value
     rp_face_value = 13 if rp_face_value == 0
 
-    cards << Card.new(rp_face_value, rp_suit)
+    cards << ::RubyPoker::Card.new(rp_face_value, rp_suit)
   end
 
-  hand = PokerHand.new(cards)
+  hand = ::RubyPoker::PokerHand.new(cards)
   score = hand.score[0][0]  # don't know what was I thinking with this double nested array
 
   if score - 1 != expected_rank

--- a/test/support/class_references.rb
+++ b/test/support/class_references.rb
@@ -1,0 +1,9 @@
+module ClassReferences
+  def poker_hand_class
+    ::RubyPoker::PokerHand
+  end
+
+  def card_class
+    ::RubyPoker::Card
+  end
+end

--- a/test/test_card.rb
+++ b/test/test_card.rb
@@ -1,47 +1,49 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
 class TestCard < Test::Unit::TestCase
+  include ClassReferences
+
   def setup
     # testing various input formats for cards
-    @c1 = Card.new("9c")
-    @c2 = Card.new("TD")
-    @c3 = Card.new("jh")
-    @c4 = Card.new("qS")
-    @c5 = Card.new("AC")
+    @c1 = card_class.new("9c")
+    @c2 = card_class.new("TD")
+    @c3 = card_class.new("jh")
+    @c4 = card_class.new("qS")
+    @c5 = card_class.new("AC")
   end
 
   def test_class_face_value
-    assert_equal(0,  Card.face_value('L'))
-    assert_equal(13, Card.face_value('A'))
+    assert_equal(0,  card_class.face_value('L'))
+    assert_equal(13, card_class.face_value('A'))
   end
 
   def test_build_from_card
-    assert_equal("9c", Card.new(@c1).to_s)
+    assert_equal("9c", card_class.new(@c1).to_s)
   end
 
   def test_build_from_value
-    assert_equal(@c1, Card.new(8))
-    assert_equal(@c2, Card.new(22))
-    assert_equal(@c3, Card.new(36))
-    assert_equal(@c4, Card.new(50))
-    assert_equal(@c5, Card.new(13))
+    assert_equal(@c1, card_class.new(8))
+    assert_equal(@c2, card_class.new(22))
+    assert_equal(@c3, card_class.new(36))
+    assert_equal(@c4, card_class.new(50))
+    assert_equal(@c5, card_class.new(13))
   end
 
   def test_build_from_face_suit
-    assert_equal(8, Card.new('9', 'c').value)
-    assert_equal(22, Card.new('T', 'd').value)
-    assert_equal(36, Card.new('J', 'h').value)
-    assert_equal(50, Card.new('Q', 's').value)
-    assert_equal(13, Card.new('A', 'c').value)
+    assert_equal(8, card_class.new('9', 'c').value)
+    assert_equal(22, card_class.new('T', 'd').value)
+    assert_equal(36, card_class.new('J', 'h').value)
+    assert_equal(50, card_class.new('Q', 's').value)
+    assert_equal(13, card_class.new('A', 'c').value)
   end
 
   def test_build_from_value_and_from_face_suit_match
     ticker = 0
-    Card::SUITS.each_char do |suit|
+    card_class::SUITS.each_char do |suit|
       "23456789TJQKA".each_char do |face|
         ticker += 1
-        from_value = Card.new(ticker)
-        from_face_suit = Card.new(face, suit)
+        from_value = card_class.new(ticker)
+        from_face_suit = card_class.new(face, suit)
         assert_equal(from_face_suit, from_value,
                      "Face and suit #{face + suit} did not match card from value #{ticker}")
       end
@@ -53,8 +55,8 @@ class TestCard < Test::Unit::TestCase
     0.upto(3) do |suit|
       1.upto(13) do |face|
         ticker += 1
-        from_value = Card.new(ticker)
-        from_face_suit_values = Card.new(face, suit)
+        from_value = card_class.new(ticker)
+        from_face_suit_values = card_class.new(face, suit)
         assert_equal(from_face_suit_values, from_value,
                      "Face=#{face} and suit=#{suit} did not match card from value #{ticker}")
       end
@@ -84,9 +86,9 @@ class TestCard < Test::Unit::TestCase
   end
 
   def test_natural_value
-    assert_equal(1, Card.new("AC").natural_value)
-    assert_equal(15, Card.new("2D").natural_value)
-    assert_equal(52, Card.new("KS").natural_value)
+    assert_equal(1, card_class.new("AC").natural_value)
+    assert_equal(15, card_class.new("2D").natural_value)
+    assert_equal(52, card_class.new("KS").natural_value)
   end
 
   def test_comparison
@@ -95,7 +97,7 @@ class TestCard < Test::Unit::TestCase
   end
 
   def test_equals
-    c = Card.new("9h")
+    c = card_class.new("9h")
     assert_not_equal(@c1, c)
     assert_equal(@c1, @c1)
   end

--- a/test/test_full_house.rb
+++ b/test/test_full_house.rb
@@ -1,14 +1,15 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
 class TestFullHouse < Test::Unit::TestCase
+  include ClassReferences
 
   context "A Full House should return the correct cards from sort_using_rank" do
 
     setup do
-      @fh_high_pair = PokerHand.new("8h 8d 8c Qh Td Kd Ks")
-      @fh_low_pair = PokerHand.new("8h 8d 8c Qh Td 4h 4d")
-      @fh_high_trips = PokerHand.new("Kh Kd Kc Qh Td 8h 8d")
-      @fh_low_trips = PokerHand.new("4h 4d 4c Qh Td Kd Ks")
+      @fh_high_pair = poker_hand_class.new("8h 8d 8c Qh Td Kd Ks")
+      @fh_low_pair = poker_hand_class.new("8h 8d 8c Qh Td 4h 4d")
+      @fh_high_trips = poker_hand_class.new("Kh Kd Kc Qh Td 8h 8d")
+      @fh_low_trips = poker_hand_class.new("4h 4d 4c Qh Td Kd Ks")
     end
 
     should "full house #sort_using_rank from seven cards (high pair) should return correct cards" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,5 @@ require 'test/unit'
 require 'shoulda-context'
 
 require 'ruby-poker'
+
+require_relative 'support/class_references'

--- a/test/test_poker_hand.rb
+++ b/test/test_poker_hand.rb
@@ -1,54 +1,56 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
 class TestPokerHand < Test::Unit::TestCase
+  include ClassReferences
+
   context "A PokerHand instance" do
 
     setup do
-      @quads = PokerHand.new('Kc Kh Kd Ks Qs')
-      @full_boat = PokerHand.new(["2H", "2D", "4C", "4D", "4S"])
-      @flush = PokerHand.new("3D 6D 7D TD QD 5H 2S")
-      @straight = PokerHand.new("8H 9D TS JH QC AS")
-      @trips = PokerHand.new("2D 9C AS AH AC")
-      @two_pair = PokerHand.new("As Ac Kc Kd 2s")
-      @pair = PokerHand.new("As Ac Kc Qd 2s")
-      @ace_high = PokerHand.new("As Jh 9c 7d 5s")
+      @quads = poker_hand_class.new('Kc Kh Kd Ks Qs')
+      @full_boat = poker_hand_class.new(["2H", "2D", "4C", "4D", "4S"])
+      @flush = poker_hand_class.new("3D 6D 7D TD QD 5H 2S")
+      @straight = poker_hand_class.new("8H 9D TS JH QC AS")
+      @trips = poker_hand_class.new("2D 9C AS AH AC")
+      @two_pair = poker_hand_class.new("As Ac Kc Kd 2s")
+      @pair = poker_hand_class.new("As Ac Kc Qd 2s")
+      @ace_high = poker_hand_class.new("As Jh 9c 7d 5s")
     end
 
     should "handle empty hands" do
-      assert_equal(PokerHand.new.rank, "Empty Hand")
+      assert_equal(poker_hand_class.new.rank, "Empty Hand")
     end
 
     should "handle single card hands" do
-      assert_equal(PokerHand.new('As').rank, @ace_high.rank)
+      assert_equal(poker_hand_class.new('As').rank, @ace_high.rank)
     end
 
     should "handle two card hands" do
-      assert_equal(PokerHand.new('As Ac').rank, @pair.rank)
+      assert_equal(poker_hand_class.new('As Ac').rank, @pair.rank)
     end
 
     should "handle three card hands" do
-      assert_equal(PokerHand.new('As Ac Ah').rank, @trips.rank)
+      assert_equal(poker_hand_class.new('As Ac Ah').rank, @trips.rank)
     end
 
     should "handle four card hands" do
-      assert_equal(PokerHand.new('As Ac Kd Kh').rank, @two_pair.rank)
-      assert_equal(PokerHand.new('As Ac Ad Ah').rank, @quads.rank)
+      assert_equal(poker_hand_class.new('As Ac Kd Kh').rank, @two_pair.rank)
+      assert_equal(poker_hand_class.new('As Ac Ad Ah').rank, @quads.rank)
     end
 
     should "handle lower case face card names" do
-      assert_equal(0, PokerHand.new('kc kd') <=> PokerHand.new('Kc Kd'))
-      assert_equal(0, PokerHand.new('kc kd') <=> PokerHand.new('Kc KD'))
+      assert_equal(0, poker_hand_class.new('kc kd') <=> poker_hand_class.new('Kc Kd'))
+      assert_equal(0, poker_hand_class.new('kc kd') <=> poker_hand_class.new('Kc KD'))
     end
 
     should "handle hands without space" do
-      assert_equal(0, PokerHand.new('KcKd') <=> PokerHand.new('Kc Kd'))
-      assert_equal(0, PokerHand.new('KcKd9d') <=> PokerHand.new('Kc Kd 9d'))
+      assert_equal(0, poker_hand_class.new('KcKd') <=> poker_hand_class.new('Kc Kd'))
+      assert_equal(0, poker_hand_class.new('KcKd9d') <=> poker_hand_class.new('Kc Kd 9d'))
     end
 
     should "raise a clear error with invalid cards" do
-      e = assert_raises(ArgumentError) { PokerHand.new('Fc') }
+      e = assert_raises(ArgumentError) { poker_hand_class.new('Fc') }
       assert_match(/"Fc"/, e.message)
-      e = assert_raises(ArgumentError) { PokerHand.new('Tp') }
+      e = assert_raises(ArgumentError) { poker_hand_class.new('Tp') }
       assert_match(/"Tp"/, e.message)
     end
 
@@ -58,8 +60,8 @@ class TestPokerHand < Test::Unit::TestCase
       assert_equal("Qd Td 7d 6d 3d 2s 5h", @flush.sort_using_rank)
       assert_equal("Qc Jh Ts 9d 8h As", @straight.sort_using_rank)
 
-      assert_equal("As Ah 3d 3c Kd", PokerHand.new("AS AH KD 3D 3C").sort_using_rank)
-      assert_equal("As Ah 3d 3c 2d", PokerHand.new("2D AS AH 3D 3C").sort_using_rank)
+      assert_equal("As Ah 3d 3c Kd", poker_hand_class.new("AS AH KD 3D 3C").sort_using_rank)
+      assert_equal("As Ah 3d 3c 2d", poker_hand_class.new("2D AS AH 3D 3C").sort_using_rank)
     end
 
     should "return card sorted by face value" do
@@ -77,12 +79,12 @@ class TestPokerHand < Test::Unit::TestCase
     should "recognize a straight flush" do
       assert !@flush.straight_flush?
       assert !@straight.straight_flush?
-      assert PokerHand.new("8H 9H TH JH QH AS").straight_flush?
+      assert poker_hand_class.new("8H 9H TH JH QH AS").straight_flush?
     end
 
     should "recognize a royal flush" do
       assert !@flush.royal_flush?
-      assert PokerHand.new("AD KD QD JD TD").royal_flush?
+      assert poker_hand_class.new("AD KD QD JD TD").royal_flush?
     end
 
     should "recognize a flush" do
@@ -92,7 +94,7 @@ class TestPokerHand < Test::Unit::TestCase
 
     should "recognize a four of a kind" do
       assert !@trips.four_of_a_kind?
-      assert PokerHand.new("AD 9C AS AH AC")
+      assert poker_hand_class.new("AD 9C AS AH AC")
     end
 
     should "recognize a full house" do
@@ -103,9 +105,9 @@ class TestPokerHand < Test::Unit::TestCase
     should "recognize a straight" do
       assert @straight.straight?
       # ace low straight
-      assert PokerHand.new("AH 2S 3D 4H 5D").straight?
+      assert poker_hand_class.new("AH 2S 3D 4H 5D").straight?
       # ace high straight
-      assert PokerHand.new("AH KS QD JH TD").straight?
+      assert poker_hand_class.new("AH KS QD JH TD").straight?
     end
 
     should "recognize a three of a kind" do
@@ -113,22 +115,22 @@ class TestPokerHand < Test::Unit::TestCase
     end
 
     should "recognize a two pair" do
-      assert PokerHand.new("2S 2D TH TD 4S").two_pair?
-      assert !PokerHand.new("6D 7C 5D 5H 3S").two_pair?
+      assert poker_hand_class.new("2S 2D TH TD 4S").two_pair?
+      assert !poker_hand_class.new("6D 7C 5D 5H 3S").two_pair?
     end
 
     should "recognize a pair" do
-      assert !PokerHand.new("5C JC 2H 7S 3D").pair?
-      assert PokerHand.new("6D 7C 5D 5H 3S").pair?
+      assert !poker_hand_class.new("5C JC 2H 7S 3D").pair?
+      assert poker_hand_class.new("6D 7C 5D 5H 3S").pair?
     end
 
     should "recognize a hand with the rank highest_card" do
       # hard to test, make sure it does not return null
-      assert PokerHand.new("2D 4S 6C 8C TH").highest_card?
+      assert poker_hand_class.new("2D 4S 6C 8C TH").highest_card?
     end
 
     should "have an instance variable hand that is an array of Cards" do
-      assert_instance_of Card, @trips.hand[0]
+      assert_instance_of card_class, @trips.hand[0]
     end
 
     should "return the hand's rating as a string" do
@@ -155,14 +157,14 @@ class TestPokerHand < Test::Unit::TestCase
     end
 
     should "return the correct number of cards in the hand" do
-      assert_equal(0, PokerHand.new.size)
-      assert_equal(1, PokerHand.new("2c").size)
-      assert_equal(2, PokerHand.new("2c 3d").size)
+      assert_equal(0, poker_hand_class.new.size)
+      assert_equal(1, poker_hand_class.new("2c").size)
+      assert_equal(2, poker_hand_class.new("2c 3d").size)
     end
 
     should "be comparable to other PokerHands" do
-      hand1 = PokerHand.new("5C JC 2H 5S 3D")
-      hand2 = PokerHand.new("6D 7C 5D 5H 3S")
+      hand1 = poker_hand_class.new("5C JC 2H 5S 3D")
+      hand2 = poker_hand_class.new("6D 7C 5D 5H 3S")
       assert_equal(1, hand1 <=> hand2)
       assert_equal(-1, hand2 <=> hand1)
     end
@@ -170,27 +172,27 @@ class TestPokerHand < Test::Unit::TestCase
     should "be considered equal to other poker hands that contain the same cards" do
       assert_equal(0, @trips <=> @trips)
 
-      hand1 = PokerHand.new("Ac Qc Ks Kd 9d 3c")
-      hand2 = PokerHand.new("Ah Qs 9h Kh Kc 3s")
+      hand1 = poker_hand_class.new("Ac Qc Ks Kd 9d 3c")
+      hand2 = poker_hand_class.new("Ah Qs 9h Kh Kc 3s")
       assert_equal(0, hand1 <=> hand2)
     end
 
     should "be able to insert new cards into the hand" do
-      ph = PokerHand.new()
+      ph = poker_hand_class.new()
       ph << "Qd"
-      ph << Card.new("2D")
+      ph << card_class.new("2D")
       ph << ["3d", "4d"]
       assert_equal("Qd 2d 3d 4d", ph.just_cards)
     end
 
     should "be able to delete a card" do
-      ph = PokerHand.new("Ac")
+      ph = poker_hand_class.new("Ac")
       ph.delete("Ac")
       assert_equal(Array.new, ph.hand)
     end
 
     should "detect the two highest pairs when there are more than two" do
-      ph = PokerHand.new("7d 7s 4d 4c 2h 2d")
+      ph = poker_hand_class.new("7d 7s 4d 4c 2h 2d")
       assert_equal([3, 6, 3, 1], ph.two_pair?[0])
       # Explanation of [3, 6, 3, 1]
       # 3: the number for a two pair
@@ -201,31 +203,31 @@ class TestPokerHand < Test::Unit::TestCase
 
     context "when duplicates are allowed" do
       setup do
-        PokerHand.allow_duplicates = true
+        poker_hand_class.allow_duplicates = true
       end
 
       should "create a PokerHand of unique cards" do
-        uniq_ph = PokerHand.new("3s 4s 3s").uniq
-        assert_instance_of(PokerHand, uniq_ph)  # want to be sure uniq hands back a PokerHand
-        assert_contains(uniq_ph.hand, Card.new('3s'))
-        assert_contains(uniq_ph.hand, Card.new('4s'))
+        uniq_ph = poker_hand_class.new("3s 4s 3s").uniq
+        assert_instance_of(poker_hand_class, uniq_ph)  # want to be sure uniq hands back a PokerHand
+        assert_contains(uniq_ph.hand, card_class.new('3s'))
+        assert_contains(uniq_ph.hand, card_class.new('4s'))
       end
 
       should "allow five of a kind" do
         # there is no five of a kind. This just tests to make sure
         # that ruby-poker doesn't crash if given 5 of the same card
-        ph = PokerHand.new("KS KS KS KS KS")
+        ph = poker_hand_class.new("KS KS KS KS KS")
         assert_equal("Four of a kind", ph.rank)
       end
 
       should "allow duplicates on initialize" do
         assert_nothing_raised RuntimeError do
-          PokerHand.new("3s 3s")
+          poker_hand_class.new("3s 3s")
         end
       end
 
       should "allow duplicate card to be added after initialize" do
-        ph = PokerHand.new("2d")
+        ph = poker_hand_class.new("2d")
         ph << "2d"
         assert_equal("2d 2d", ph.just_cards)
       end
@@ -233,28 +235,28 @@ class TestPokerHand < Test::Unit::TestCase
 
     context "when duplicates are not allowed" do
       setup do
-        PokerHand.allow_duplicates = false
+        poker_hand_class.allow_duplicates = false
       end
 
       should "not allow duplicates on initialize" do
-        PokerHand.allow_duplicates = false
+        poker_hand_class.allow_duplicates = false
 
         assert_raise RuntimeError do
-          PokerHand.new("3s 3s")
+          poker_hand_class.new("3s 3s")
         end
 
-        PokerHand.allow_duplicates = true
+        poker_hand_class.allow_duplicates = true
       end
 
       should "not allow duplicates after initialize" do
-        PokerHand.allow_duplicates = false
+        poker_hand_class.allow_duplicates = false
 
-        ph = PokerHand.new("2d")
+        ph = poker_hand_class.new("2d")
         assert_raise RuntimeError do
           ph << "2d"
         end
 
-        PokerHand.allow_duplicates = true
+        poker_hand_class.allow_duplicates = true
       end
     end
 
@@ -267,25 +269,25 @@ class TestPokerHand < Test::Unit::TestCase
     end
 
     should "be Enumerable" do
-      assert PokerHand.include?(Enumerable)
+      assert poker_hand_class.include?(Enumerable)
     end
   end
 
   context "addition" do
     setup do
-      @base = PokerHand.new('Ac Kc')
+      @base = poker_hand_class.new('Ac Kc')
     end
 
     should "work with a string" do
-      assert_equal PokerHand.new('Ac Kc Qc'), @base + 'Qc'
+      assert_equal poker_hand_class.new('Ac Kc Qc'), @base + 'Qc'
     end
 
     should "work with a card" do
-      assert_equal PokerHand.new('Ac Kc Qc'), @base + Card.new('Qc')
+      assert_equal poker_hand_class.new('Ac Kc Qc'), @base + card_class.new('Qc')
     end
 
     should "work with a hand" do
-      assert_equal PokerHand.new('Ac Kc Qc'), @base + PokerHand.new('Qc')
+      assert_equal poker_hand_class.new('Ac Kc Qc'), @base + poker_hand_class.new('Qc')
     end
 
     should "not modify the receiver hand" do
@@ -295,26 +297,26 @@ class TestPokerHand < Test::Unit::TestCase
 
     should "not affect receiver cards" do
       result = @base + 'Qc'
-      result.to_a.first.instance_eval { @face = Card.face_value('2') }
-      assert_equal PokerHand.new('Ac Kc'), @base
+      result.to_a.first.instance_eval { @face = ::RubyPoker::Card.face_value('2') }
+      assert_equal poker_hand_class.new('Ac Kc'), @base
     end
   end
 
   context "PokerHand#pair?" do
 
     should "return false with one card" do
-      assert !PokerHand.new("2h").pair?
+      assert !poker_hand_class.new("2h").pair?
     end
 
     context "with a pair" do
 
       should "return 2, followed by the pair value" do
-        assert_equal [2, 5-1], PokerHand.new("5h 5s").pair?[0]
+        assert_equal [2, 5-1], poker_hand_class.new("5h 5s").pair?[0]
       end
 
       context "with a two card hand" do
         setup do
-          @ph = PokerHand.new("5h 5s")
+          @ph = poker_hand_class.new("5h 5s")
           @scoring = @ph.pair?[0]
         end
 
@@ -325,7 +327,7 @@ class TestPokerHand < Test::Unit::TestCase
 
       context "with a three card hand" do
         setup do
-          @ph = PokerHand.new("5h 5s 8s")
+          @ph = poker_hand_class.new("5h 5s 8s")
           @scoring = @ph.pair?[0]
         end
 
@@ -340,7 +342,7 @@ class TestPokerHand < Test::Unit::TestCase
 
       context "with a four card hand" do
         setup do
-          @ph = PokerHand.new("5h 5s 8s 7s")
+          @ph = poker_hand_class.new("5h 5s 8s 7s")
           @scoring = @ph.pair?[0]
         end
 
@@ -356,7 +358,7 @@ class TestPokerHand < Test::Unit::TestCase
 
       context "with a five (or more) card hand" do
         setup do
-          @ph = PokerHand.new("5h 5s 8s 7s 6s 2h")
+          @ph = poker_hand_class.new("5h 5s 8s 7s 6s 2h")
           @scoring = @ph.pair?[0]
         end
 
@@ -374,19 +376,19 @@ class TestPokerHand < Test::Unit::TestCase
 
     context "without a pair" do
       should "return false" do
-        assert !PokerHand.new("2h 3h").pair?
+        assert !poker_hand_class.new("2h 3h").pair?
       end
     end
   end
 
 
   def assert_hand_match(expression, cards)
-    hand = PokerHand.new(cards)
+    hand = poker_hand_class.new(cards)
     assert hand.match?(expression), "#{cards} didn't match #{expression}"
   end
 
   def assert_hand_not_match(expression, cards)
-    hand = PokerHand.new(cards)
+    hand = poker_hand_class.new(cards)
     assert !hand.match?(expression), "#{cards} did match #{expression}"
   end
 
@@ -508,7 +510,7 @@ class TestPokerHand < Test::Unit::TestCase
       %w(Ac Kc Qc Jc Tc),
     ].each do |cards|
       should "raise an error if the number of cards is #{cards.size}" do
-        hand = PokerHand.new(cards)
+        hand = poker_hand_class.new(cards)
         assert_raises RuntimeError do
           hand.match?('AA')
         end
@@ -516,7 +518,7 @@ class TestPokerHand < Test::Unit::TestCase
     end
 
     should "raise an error with invalid expression" do
-      hand = PokerHand.new("Ac Kc")
+      hand = poker_hand_class.new("Ac Kc")
       assert_raises ArgumentError do
         hand.match? "foo"
       end


### PR DESCRIPTION
Other Ruby libraries implement the Card class. By namespacing, we can avoid conflicts.

While this looks like a massive change, it's really just indenting all the lines. There may also be concerns about backwards compatibility with other code folks have written against this library, but I think this is a worthwhile change.
