### PR TITLE
Support ruby 2.2 for developer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
   - jruby
   - rbx
 # uncomment this line if your project needs to run something other than `rake`:

--- a/ruby-poker.gemspec
+++ b/ruby-poker.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |s|
                     '--main'  << 'README.rdoc' <<
                     '--inline-source' << '-q'
 
+  s.add_development_dependency('test-unit', '~> 3.1') if /^2.[2-9]/ =~ RUBY_VERSION && RUBY_ENGINE == 'ruby'
   s.add_development_dependency('shoulda-context', '~> 1.1')
 end


### PR DESCRIPTION
- Add 2.2 to travis CI
- Add unittest dependencies to ruby 2.2 and up ruby 2

I don't think I change any logic, so stick to current release version should be fine.